### PR TITLE
Cast point coordinates to floats

### DIFF
--- a/mean_shift.py
+++ b/mean_shift.py
@@ -12,6 +12,7 @@ class MeanShift(object):
         self.kernel = kernel
 
     def cluster(self, points, kernel_bandwidth, iteration_callback=None):
+        points = np.array([[float(v) for v in point] for point in points])
         if(iteration_callback):
             iteration_callback(points, 0)
         shift_points = np.array(points)


### PR DESCRIPTION
Before clustering cast all numbers to floats (in case integers where provided - fixes #10).
Additionally I'm wrapping points in `np.array()` so simple lists can be passed in `points` argument.